### PR TITLE
fix: Disable self-updater in CI builds from push

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -38,6 +38,12 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
+    - name: Disable self-updater
+      shell: bash
+      run: |
+        jq '.tauri.updater.active = false' src-tauri/tauri.conf.json > src-tauri/tauri.conf.json.new
+        rm src-tauri/tauri.conf.json
+        mv src-tauri/tauri.conf.json.new src-tauri/tauri.conf.json
     - name: install app dependencies and build it
       env:
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}


### PR DESCRIPTION
Remedies the issue that anyone pushing without access to private key will see their CI fail.