### PR TITLE
feat: Enable dev mode directly if in debug mode

### DIFF
--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -134,6 +134,11 @@ export const store = createStore<FlightCoreStore>({
  * It invokes all Rust methods that are needed to initialize UI.
  */
 async function _initializeApp(state: any) {
+    // Enable dev mode directly if application is in debug mode
+    if (await invoke("is_debug_mode")) {
+        state.developer_mode = true;
+    }
+
     const result = await invoke("find_game_install_location_caller")
         .catch((err) => {
             // Gamepath not found or other error


### PR DESCRIPTION
Allows skipping clicking version number 5 times when working on FlightCore.
Release builds are not in debug mode, so dev mode is still disabled by default for end-users.