### PR TITLE
feat: Add persistent store

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,37 @@ Note that you can adjust the behaviour of Tauri windows in `tauri.conf.json`, e.
 ]
 ```
 
+### Docs
+
+In regards to storing persistent data, FlightCore uses [`tauri-plugin-store`](https://github.com/tauri-apps/tauri-plugin-store). It's a key-value store accessed in frontend to load and store small amounts of data.
+
+The goal is to store as little data in there as possible and instead get the necessary info on app launch.
+For example the install path of Titanfall2 should be inferred everytime on launch using Steam library or Origin, so that if the player changes the install location, there's no need to sync it up with the persistent store again.
+The exception to this is when Steam/Origin is unable to find the install location and the user manually selected a location instead. In this case, we don't want to re-prompt the user on every launch of FlightCore to enter the Titanfall2 install location.
+
+**Usage example for `tauri-plugin-store`:**
+
+```typescript
+// Import the lib
+import { Store } from 'tauri-plugin-store-api';
+// Define a store based on filename to write to
+const persistentStore = new Store('flight-core-settings.json');
+
+// Save change in persistent store
+await persistentStore.set('northstar-release-canal', { value: "NorthstarReleasecandidate" });
+
+// Grab Northstar release canal value from store if exists
+var persistent_northstar_release_canal = (await persistentStore.get('northstar-release-canal')) as any;
+if(persistent_northstar_release_canal) { // For some reason, the plugin-store doesn't throw an eror but simply returns `null` when key not found
+    // Put value from peristent store into current store
+    state.northstar_release_canal = persistent_northstar_release_canal.value as string;
+}
+else {
+    console.log("Value not found in store");
+}
+
+```
+
 ### Building
 
 Release builds are generally done via CI. To build locally, make sure typescript is compiled (`./node_modules/.bin/rollup --config`), then run `npm run tauri build`.

--- a/src-vue/package-lock.json
+++ b/src-vue/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@element-plus/icons-vue": "^2.0.9",
         "element-plus": "^2.2.17",
+        "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#dev",
         "vue": "^3.2.37",
         "vuex": "^4.0.2"
       },
@@ -103,6 +104,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@tauri-apps/api": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-n13pIqdPd3KtaMmmAcrU7BTfdMtIlGNnfZD0dNX8L4p8dgmuNyikm6JAA+yCpl9gqq6I8x5cV2Y0muqdgD0cWw==",
+      "engines": {
+        "node": ">= 12.22.0",
+        "npm": ">= 6.6.0",
+        "yarn": ">= 1.19.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
       }
     },
     "node_modules/@types/lodash": {
@@ -1036,6 +1051,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tauri-plugin-store-api": {
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/tauri-apps/tauri-plugin-store.git#4326f75446b8b9e0cb9904c65f258b81e23e544e",
+      "license": "MIT",
+      "dependencies": {
+        "@tauri-apps/api": "1.1.0",
+        "tslib": "2.4.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "node_modules/typescript": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
@@ -1187,6 +1216,11 @@
       "version": "npm:@sxzz/popperjs-es@2.11.7",
       "resolved": "https://registry.npmjs.org/@sxzz/popperjs-es/-/popperjs-es-2.11.7.tgz",
       "integrity": "sha512-Ccy0NlLkzr0Ex2FKvh2X+OyERHXJ88XJ1MXtsI9y9fGexlaXaVTPzBCRBwIxFkORuOb+uBqeu+RqnpgYTEZRUQ=="
+    },
+    "@tauri-apps/api": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-n13pIqdPd3KtaMmmAcrU7BTfdMtIlGNnfZD0dNX8L4p8dgmuNyikm6JAA+yCpl9gqq6I8x5cV2Y0muqdgD0cWw=="
     },
     "@types/lodash": {
       "version": "4.14.185",
@@ -1803,6 +1837,19 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "tauri-plugin-store-api": {
+      "version": "git+ssh://git@github.com/tauri-apps/tauri-plugin-store.git#4326f75446b8b9e0cb9904c65f258b81e23e544e",
+      "from": "tauri-plugin-store-api@https://github.com/tauri-apps/tauri-plugin-store#dev",
+      "requires": {
+        "@tauri-apps/api": "1.1.0",
+        "tslib": "2.4.0"
+      }
+    },
+    "tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "typescript": {
       "version": "4.8.3",

--- a/src-vue/package.json
+++ b/src-vue/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@element-plus/icons-vue": "^2.0.9",
     "element-plus": "^2.2.17",
+    "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#dev",
     "vue": "^3.2.37",
     "vuex": "^4.0.2"
   },

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -19,7 +19,7 @@ export interface FlightCoreStore {
 
     installed_northstar_version: string,
     northstar_state: NorthstarState,
-    release_canal: ReleaseCanal,
+    northstar_release_canal: ReleaseCanal,
 
     northstar_is_running: boolean,
     origin_is_running: boolean
@@ -37,7 +37,7 @@ export const store = createStore<FlightCoreStore>({
 
             installed_northstar_version: "",
             northstar_state: NorthstarState.GAME_NOT_FOUND,
-            release_canal: ReleaseCanal.RELEASE,
+            northstar_release_canal: ReleaseCanal.RELEASE,
 
             northstar_is_running: false,
             origin_is_running: false
@@ -68,7 +68,7 @@ export const store = createStore<FlightCoreStore>({
             switch (state.northstar_state) {
                 // Install northstar if it wasn't detected.
                 case NorthstarState.INSTALL:
-                    let install_northstar_result = invoke("install_northstar_caller", { gamePath: state.game_path, northstarPackageName: state.release_canal });
+                    let install_northstar_result = invoke("install_northstar_caller", { gamePath: state.game_path, northstarPackageName: state.northstar_release_canal });
                     state.northstar_state = NorthstarState.INSTALLING;
 
                     await install_northstar_result.then((message) => {
@@ -85,7 +85,7 @@ export const store = createStore<FlightCoreStore>({
                 // Update northstar if it is outdated.
                 case NorthstarState.MUST_UPDATE:
                     // Updating is the same as installing, simply overwrites the existing files
-                    let reinstall_northstar_result = invoke("install_northstar_caller", { gamePath: state.game_path, northstarPackageName: state.release_canal });
+                    let reinstall_northstar_result = invoke("install_northstar_caller", { gamePath: state.game_path, northstarPackageName: state.northstar_release_canal });
                     state.northstar_state = NorthstarState.UPDATING;
 
                     await reinstall_northstar_result.then((message) => {
@@ -205,7 +205,7 @@ async function _get_northstar_version_number(state: any) {
         state.installed_northstar_version = northstar_version_number;
         state.northstar_state = NorthstarState.READY_TO_PLAY;
 
-        await invoke("check_is_northstar_outdated", { gamePath: state.game_path, northstarPackageName: state.release_canal })
+        await invoke("check_is_northstar_outdated", { gamePath: state.game_path, northstarPackageName: state.northstar_release_canal })
             .then((message) => {
                 if (message) {
                     state.northstar_state = NorthstarState.MUST_UPDATE;

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -7,6 +7,9 @@ import { GameInstall } from "../utils/GameInstall";
 import { ReleaseCanal } from "../utils/ReleaseCanal";
 import { ElNotification } from 'element-plus';
 import { NorthstarState } from '../utils/NorthstarState';
+import { Store } from 'tauri-plugin-store-api';
+
+const persistentStore = new Store('flight-core-settings.json');
 
 
 export interface FlightCoreStore {
@@ -141,6 +144,16 @@ async function _initializeApp(state: any) {
     // Enable dev mode directly if application is in debug mode
     if (await invoke("is_debug_mode")) {
         state.developer_mode = true;
+    }
+
+    // Grab Northstar release canal value from store if exists
+    var persistent_northstar_release_canal = (await persistentStore.get('northstar-release-canal')) as any;
+    if(persistent_northstar_release_canal) { // For some reason, the plugin-store doesn't throw an eror but simply returns `null` when key not found
+        // Put value from peristent store into current store
+        state.northstar_release_canal = persistent_northstar_release_canal.value as string;
+    }
+    else {
+        console.log("Value not found in store");
     }
 
     // Get FlightCore version number

--- a/src-vue/src/views/DeveloperView.vue
+++ b/src-vue/src/views/DeveloperView.vue
@@ -27,6 +27,8 @@ import { invoke } from "@tauri-apps/api";
 import { ElNotification } from "element-plus";
 import { ReleaseCanal } from "../utils/ReleaseCanal";
 import { GameInstall } from "../utils/GameInstall";
+import { Store } from 'tauri-plugin-store-api';
+const persistentStore = new Store('flight-core-settings.json');
 
 export default defineComponent({
     name: "DeveloperView",
@@ -48,6 +50,9 @@ export default defineComponent({
             this.$store.state.northstar_release_canal = this.$store.state.northstar_release_canal === ReleaseCanal.RELEASE
                 ? ReleaseCanal.RELEASE_CANDIDATE
                 : ReleaseCanal.RELEASE;
+
+            // Save change in persistent store
+            await persistentStore.set('northstar-release-canal', { value: this.$store.state.northstar_release_canal });
 
             // Update current state so that update check etc can be performed
             this.$store.commit("checkNorthstarUpdates");

--- a/src-vue/src/views/DeveloperView.vue
+++ b/src-vue/src/views/DeveloperView.vue
@@ -45,7 +45,7 @@ export default defineComponent({
         },
         async toggleReleaseCandidate() {
             // Flip between RELEASE and RELEASE_CANDIDATE
-            this.$store.state.release_canal = this.$store.state.release_canal === ReleaseCanal.RELEASE
+            this.$store.state.northstar_release_canal = this.$store.state.northstar_release_canal === ReleaseCanal.RELEASE
                 ? ReleaseCanal.RELEASE_CANDIDATE
                 : ReleaseCanal.RELEASE;
 
@@ -56,8 +56,8 @@ export default defineComponent({
 
             // Display notification to highlight change
             ElNotification({
-                title: `${this.$store.state.release_canal}`,
-                message: `Switched release channel to: "${this.$store.state.release_canal}"`,
+                title: `${this.$store.state.northstar_release_canal}`,
+                message: `Switched release channel to: "${this.$store.state.northstar_release_canal}"`,
                 type: 'success',
                 position: 'bottom-right'
             });


### PR DESCRIPTION
Adds persistent store using [`tauri-plugin-store`](https://github.com/tauri-apps/tauri-plugin-store).

For now, it's only used to store the selected release canal.