### PR TITLE
refactor: Use `Result<>` return type for Linux checks

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,16 +46,19 @@ pub fn check_mod_version_number(path_to_mod_folder: String) -> Result<String, an
 // for now tho it only checks `ldd --version`
 // - salmon
 
-pub fn linux_checks_librs() -> bool {
-    let mut linux_compatible: bool = true; // a variable that starts true and will be set to false if any of the checks arent met
+pub fn linux_checks_librs() -> Result<(), String> {
+    // Perform various checks in terms of Linux compatibility
+    // Return early with error message if a check fails
 
     // check `ldd --version` to see if glibc is up to date for northstar proton
     let lddv = linux::check_glibc_v();
-    if lddv < 2.33 { linux_compatible = false };
+    if lddv < 2.33 {
+        return Err("GLIBC is not version 2.33 or greater".to_string());
+    };
 
-    return linux_compatible;
+    // All checks passed
+    Ok(())
 }
-
 
 /// Attempts to find the game install location
 pub fn find_game_install_location() -> Result<GameInstall, anyhow::Error> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,9 +51,14 @@ pub fn linux_checks_librs() -> Result<(), String> {
     // Return early with error message if a check fails
 
     // check `ldd --version` to see if glibc is up to date for northstar proton
+    let min_required_ldd_version = 2.33;
     let lddv = linux::check_glibc_v();
-    if lddv < 2.33 {
-        return Err("GLIBC is not version 2.33 or greater".to_string());
+    if lddv < min_required_ldd_version {
+        return Err(format!(
+            "GLIBC is not version {} or greater",
+            min_required_ldd_version
+        )
+        .to_string());
     };
 
     // All checks passed

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -120,12 +120,13 @@ fn is_debug_mode() -> bool {
 
 #[tauri::command]
 /// Returns true if linux compatible
-fn linux_checks() -> bool {
-    if get_host_os() == "windows" { 
-        false
-    } else {
-        linux_checks_librs()
+fn linux_checks() -> Result<(), String> {
+    // Early return if Windows
+    if get_host_os() == "windows" {
+        return Err("Not available on Windows".to_string());
     }
+
+    linux_checks_librs()
 }
 
 #[tauri::command]

--- a/src-vue/src/views/DeveloperView.vue
+++ b/src-vue/src/views/DeveloperView.vue
@@ -50,22 +50,24 @@ export default defineComponent({
             });
         },
         async checkLinuxCompatibility() {
-            let LinuxCompatible = await invoke("linux_checks");
-            if (!LinuxCompatible) {
-                ElNotification({
-                    title: 'Not linux compatible',
-                    message: 'GLIBC is not version 2.33 or greater',
-                    type: 'error',
-                    position: 'bottom-right'
+            await invoke("linux_checks")
+                .then(() => {
+                    ElNotification({
+                        title: 'Linux compatible',
+                        message: 'All checks passed',
+                        type: 'success',
+                        position: 'bottom-right'
+                    });
+                })
+                .catch((error) => {
+                    ElNotification({
+                        title: 'Not linux compatible',
+                        message: error,
+                        type: 'error',
+                        position: 'bottom-right'
+                    });
+                    console.error(error);
                 });
-            } else {
-                ElNotification({
-                    title: 'Linux compatible',
-                    message: 'No error reported',
-                    type: 'success',
-                    position: 'bottom-right'
-                });
-            }
         },
         async toggleReleaseCandidate() {
             // Flip between RELEASE and RELEASE_CANDIDATE


### PR DESCRIPTION
Allows for comprehensive error messages depending on which check failed (we only have one check right now but that will change in the future).