### PR TITLE
refactor: Make all functions async

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -97,7 +97,7 @@ fn main() {
 
 #[tauri::command]
 /// Wrapper for `find_game_install_location` as tauri doesn't allow passing `Result<>` types to front-end
-fn find_game_install_location_caller() -> Result<GameInstall, String> {
+async fn find_game_install_location_caller() -> Result<GameInstall, String> {
     match find_game_install_location() {
         Ok(game_install) => Ok(game_install),
         Err(err) => {
@@ -109,19 +109,20 @@ fn find_game_install_location_caller() -> Result<GameInstall, String> {
 
 #[tauri::command]
 /// This function's only use is to force a `panic!()`
+// This must NOT be async to ensure crashing whole application.
 fn force_panic() {
     panic!("Force panicked!");
 }
 
 #[tauri::command]
 /// Returns true if built in debug mode
-fn is_debug_mode() -> bool {
+async fn is_debug_mode() -> bool {
     return cfg!(debug_assertions);
 }
 
 #[tauri::command]
 /// Returns true if linux compatible
-fn linux_checks() -> Result<(), String> {
+async fn linux_checks() -> Result<(), String> {
     // Early return if Windows
     if get_host_os() == "windows" {
         return Err("Not available on Windows".to_string());
@@ -132,7 +133,7 @@ fn linux_checks() -> Result<(), String> {
 
 #[tauri::command]
 /// Returns the current version number as a string
-fn get_flightcore_version_number() -> String {
+async fn get_flightcore_version_number() -> String {
     let version = env!("CARGO_PKG_VERSION");
     if cfg!(debug_assertions) {
         // Debugging enabled
@@ -144,7 +145,7 @@ fn get_flightcore_version_number() -> String {
 }
 
 #[tauri::command]
-fn get_northstar_version_number_caller(game_path: String) -> String {
+async fn get_northstar_version_number_caller(game_path: String) -> String {
     match get_northstar_version_number(game_path) {
         Ok(version_number) => version_number,
         Err(err) => {
@@ -207,13 +208,13 @@ async fn check_is_northstar_outdated(
 /// Checks if installed FlightCore version is up-to-date
 /// false -> FlightCore install is up-to-date
 /// true  -> FlightCore install is outdated
-fn check_is_flightcore_outdated_caller() -> Result<bool, String> {
+async fn check_is_flightcore_outdated_caller() -> Result<bool, String> {
     check_is_flightcore_outdated()
 }
 
 #[tauri::command]
 /// Checks if is valid Titanfall2 install based on certain conditions
-fn verify_install_location(game_path: String) -> bool {
+async fn verify_install_location(game_path: String) -> bool {
     match check_is_valid_game_path(&game_path) {
         Ok(()) => true,
         Err(err) => {
@@ -225,7 +226,7 @@ fn verify_install_location(game_path: String) -> bool {
 
 #[tauri::command]
 /// Returns identifier of host OS FlightCore is running on
-fn get_host_os_caller() -> String {
+async fn get_host_os_caller() -> String {
     get_host_os()
 }
 
@@ -265,28 +266,28 @@ async fn update_northstar_caller(
 
 #[tauri::command]
 /// Launches Northstar
-fn launch_northstar_caller(game_install: GameInstall) -> Result<String, String> {
+async fn launch_northstar_caller(game_install: GameInstall) -> Result<String, String> {
     launch_northstar(game_install)
 }
 
 #[tauri::command]
 /// Get list of Northstar logs
-fn get_log_list_caller(game_install: GameInstall) -> Result<Vec<std::path::PathBuf>, String> {
+async fn get_log_list_caller(game_install: GameInstall) -> Result<Vec<std::path::PathBuf>, String> {
     get_log_list(game_install)
 }
 
 #[tauri::command]
-fn verify_game_files_caller(game_install: GameInstall) -> Result<String, String> {
+async fn verify_game_files_caller(game_install: GameInstall) -> Result<String, String> {
     verify_game_files(game_install)
 }
 
 #[tauri::command]
-fn get_enabled_mods_caller(game_install: GameInstall) -> Result<serde_json::value::Value, String> {
+async fn get_enabled_mods_caller(game_install: GameInstall) -> Result<serde_json::value::Value, String> {
     get_enabled_mods(game_install)
 }
 
 #[tauri::command]
-fn set_mod_enabled_status_caller(
+async fn set_mod_enabled_status_caller(
     game_install: GameInstall,
     mod_name: String,
     is_enabled: bool,
@@ -295,7 +296,7 @@ fn set_mod_enabled_status_caller(
 }
 
 #[tauri::command]
-fn disable_all_but_core_caller(game_install: GameInstall) -> Result<(), String> {
+async fn disable_all_but_core_caller(game_install: GameInstall) -> Result<(), String> {
     disable_all_but_core(game_install)
 }
 


### PR DESCRIPTION
This way none of them are run on main thread and as such if a function panics, it will only crash that specific thread allowing the rest of the application to survive.

The only exception is `force_panic()` as its purpose is hard crashing the application.

From the frontend side of things, `invoke()` is already async, so no frontend changes are needed.