### PR TITLE
refactor: Return error string instead of `anyhow!()`

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -72,7 +72,7 @@ pub fn linux_checks_librs() -> Result<(), String> {
 }
 
 /// Attempts to find the game install location
-pub fn find_game_install_location() -> Result<GameInstall, anyhow::Error> {
+pub fn find_game_install_location() -> Result<GameInstall, String> {
     // Attempt parsing Steam library directly
     match steamlocate::SteamDir::locate() {
         Some(mut steamdir) => {
@@ -107,9 +107,7 @@ pub fn find_game_install_location() -> Result<GameInstall, anyhow::Error> {
         }
     };
 
-    Err(anyhow!(
-        "Could not auto-detect game install location! Please enter it manually."
-    ))
+    Err("Could not auto-detect game install location! Please enter it manually.".to_string())
 }
 
 /// Returns the current Northstar version number as a string

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -98,13 +98,7 @@ fn main() {
 #[tauri::command]
 /// Wrapper for `find_game_install_location` as tauri doesn't allow passing `Result<>` types to front-end
 fn find_game_install_location_caller() -> Result<GameInstall, String> {
-    match find_game_install_location() {
-        Ok(game_install) => Ok(game_install),
-        Err(err) => {
-            println!("{}", err);
-            Err(err.to_string())
-        }
-    }
+    find_game_install_location()
 }
 
 #[tauri::command]


### PR DESCRIPTION
All that is returned as the error type is a string so there's no point in using a custom error type when we can just have the error type be a string.