### PR TITLE
refactor: Clicking FC version activates dev

### DIFF
--- a/src-vue/src/views/PlayView.vue
+++ b/src-vue/src/views/PlayView.vue
@@ -5,11 +5,6 @@ import PlayButton from '../components/PlayButton.vue';
 import { defineComponent } from "vue";
 
 export default defineComponent({
-    data() {
-        return {
-            developerModeClicks: 0
-        }
-    },
     components: {
         PlayButton
     },
@@ -22,20 +17,6 @@ export default defineComponent({
         },
     },
     methods: {
-        activateDeveloperMode() {
-            this.developerModeClicks += 1;
-            if (this.developerModeClicks >= 6) {
-                this.$store.state.developer_mode = true;
-                ElNotification({
-                    title: 'Watch out!',
-                    message: 'Developer mode enabled.',
-                    type: 'info',
-                    position: 'bottom-right'
-                });
-                this.developerModeClicks = 0;
-            }
-        },
-
         showChangelogPage() {
             this.$store.commit('updateCurrentTab', Tabs.CHANGELOG);
         }
@@ -47,9 +28,7 @@ export default defineComponent({
     <div class="fc_launch__container">
         <div class="fc_title">Northstar</div>
         <div class="fc_northstar__version__container">
-            <div class="fc_northstar__version" @click="activateDeveloperMode">
-                {{ northstarVersion === '' ? 'Unknown version' : `v${northstarVersion}` }}
-            </div>
+            {{ northstarVersion === '' ? 'Unknown version' : `v${northstarVersion}` }}
             <div v-if="northstarVersion !== ''" class="fc_changelog__link" @click="showChangelogPage">
                 (see patch notes)
             </div>

--- a/src-vue/src/views/SettingsView.vue
+++ b/src-vue/src/views/SettingsView.vue
@@ -13,7 +13,9 @@
             </template>
         </el-input>
         <h3>About:</h3>
-        FlightCore Version: {{ flightcoreVersion === '' ? 'Unknown version' : `${flightcoreVersion}` }}
+        <div class="fc_northstar__version" @click="activateDeveloperMode">
+            FlightCore Version: {{ flightcoreVersion === '' ? 'Unknown version' : `${flightcoreVersion}` }}
+        </div>
         <br />
         <br />
         UI design inspired by <el-link :underline="false" target="_blank" href="https://github.com/TFORevive/tforevive_launcher/" type="primary">TFORevive Launcher</el-link> (not yet public)
@@ -22,15 +24,34 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
+import { ElNotification } from 'element-plus';
 
 export default defineComponent({
     name: "SettingsView",
+    data() {
+        return {
+            developerModeClicks: 0
+        }
+    },
     computed: {
         flightcoreVersion(): string {
             return this.$store.state.flightcore_version;
         },
     },
     methods: {
+        activateDeveloperMode() {
+            this.developerModeClicks += 1;
+            if (this.developerModeClicks >= 6) {
+                this.$store.state.developer_mode = true;
+                ElNotification({
+                    title: 'Watch out!',
+                    message: 'Developer mode enabled.',
+                    type: 'info',
+                    position: 'bottom-right'
+                });
+                this.developerModeClicks = 0;
+            }
+        },
         async updateGamePath() {
             this.$store.commit('updateGamePath');
         }


### PR DESCRIPTION
Clicking FC version activates dev instead of clicking Northstar version.

Makes dev mode a bit more "hidden" (i.e. less likely to be accidentally opened by end-user) and it's more logical to click FlightCore version to open **FlightCore** dev mode as opposed to clicking Northstar version.