### PR TITLE
refactor: Return Result<> for getting NS version

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -146,13 +146,10 @@ async fn get_flightcore_version_number() -> String {
 }
 
 #[tauri::command]
-async fn get_northstar_version_number_caller(game_path: String) -> String {
+async fn get_northstar_version_number_caller(game_path: String) -> Result<String, String> {
     match get_northstar_version_number(game_path) {
-        Ok(version_number) => version_number,
-        Err(err) => {
-            println!("{}", err);
-            "".to_string()
-        }
+        Ok(version_number) => Ok(version_number),
+        Err(err) => Err(err.to_string()),
     }
 }
 

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -269,12 +269,13 @@ function _initializeListeners(state: any) {
  * state, for it to be displayed in UI.
  */
 async function _get_northstar_version_number(state: any) {
-    let northstar_version_number: string = await invoke("get_northstar_version_number_caller", { gamePath: state.game_path });
-    if (northstar_version_number && northstar_version_number.length > 0) {
+    await invoke("get_northstar_version_number_caller", { gamePath: state.game_path })
+    .then((message) => {
+        let northstar_version_number: string = message as string;
         state.installed_northstar_version = northstar_version_number;
         state.northstar_state = NorthstarState.READY_TO_PLAY;
 
-        await invoke("check_is_northstar_outdated", { gamePath: state.game_path, northstarPackageName: state.northstar_release_canal })
+        invoke("check_is_northstar_outdated", { gamePath: state.game_path, northstarPackageName: state.northstar_release_canal })
             .then((message) => {
                 if (message) {
                     state.northstar_state = NorthstarState.MUST_UPDATE;
@@ -284,8 +285,8 @@ async function _get_northstar_version_number(state: any) {
                 console.error(error);
                 alert(error);
             });
-    }
-    else {
+    })
+    .catch((error) => {
         state.northstar_state = NorthstarState.INSTALL;
-    }
+    })
 }


### PR DESCRIPTION
Return `Result<String, String>` for getting Northstar version as opposed to using an empty string to indicate an error.