### PR TITLE
refactor: Splice out GH release API fetch function

### DIFF
--- a/src-tauri/src/github/release_notes.rs
+++ b/src-tauri/src/github/release_notes.rs
@@ -8,11 +8,10 @@ pub struct ReleaseInfo {
     pub body: String
 }
 
-#[tauri::command]
-pub async fn get_northstar_release_notes() -> Result<Vec<ReleaseInfo>, String> {
+// Fetches repo release API and returns response as string
+async fn fetch_github_releases_api(url: &str) -> Result<String, String> {
     println!("Fetching releases notes from GitHub API");
 
-    let url = "https://api.github.com/repos/R2Northstar/Northstar/releases";
     let user_agent = "GeckoEidechse/FlightCore";
     let client = reqwest::Client::new();
     let res = client
@@ -25,10 +24,18 @@ pub async fn get_northstar_release_notes() -> Result<Vec<ReleaseInfo>, String> {
         .await
         .unwrap();
 
+    Ok(res)
+}
+
+#[tauri::command]
+pub async fn get_northstar_release_notes() -> Result<Vec<ReleaseInfo>, String> {
+    let url = "https://api.github.com/repos/R2Northstar/Northstar/releases";
+    let res = fetch_github_releases_api(url).await?;
+
     let json_response: Vec<serde_json::Value> =
         serde_json::from_str(&res).expect("JSON was not well-formatted");
     println!("Done checking GitHub API");
-    
+
     return Ok(
         json_response.iter().map(|release| ReleaseInfo {
             name: release.get("name")


### PR DESCRIPTION
So that it can be re-used by other functions later such as for checking newest FlightCore version by checking against GitHub releases.