### PR TITLE
feat: Show stripped title bar on debug build

### DIFF
--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -41,7 +41,6 @@ export default {
         default-active="/"
         router
         mode="horizontal"
-        class="developer_build"
         id="fc__menu_bar"
         data-tauri-drag-region
     >

--- a/src-vue/src/App.vue
+++ b/src-vue/src/App.vue
@@ -41,6 +41,7 @@ export default {
         default-active="/"
         router
         mode="horizontal"
+        class="developer_build"
         id="fc__menu_bar"
         data-tauri-drag-region
     >
@@ -101,6 +102,16 @@ export default {
   backdrop-filter: saturate(50%) blur(4px);
   background-color: transparent;
   height: var(--fc-menu_height);
+}
+
+.developer_build {
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(0, 0, 0, 0.2),
+    rgba(0, 0, 0, 0.2) 20px,
+    rgba(0, 0, 0, 0.3) 20px,
+    rgba(0, 0, 0, 0.3) 40px
+  );
 }
 
 /* Window controls */

--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -200,6 +200,12 @@ async function _initializeApp(state: any) {
     // Enable dev mode directly if application is in debug mode
     if (await invoke("is_debug_mode")) {
         state.developer_mode = true;
+
+        // Make menubar striped if debug build
+        let menu_bar_handle = document.querySelector('#fc__menu_bar');
+        if (menu_bar_handle !== null) {
+            menu_bar_handle.classList.toggle('developer_build');
+        }
     }
 
     // Grab Northstar release canal value from store if exists


### PR DESCRIPTION
Helps with differentiating which window is which when both developing FlightCore and is using release version at the same time.
Wouldn't be the first time I accidentally nearly confused the two :P


Rendered result:
![image](https://user-images.githubusercontent.com/40122905/201480628-df84cc09-23ab-4856-a4f1-c7ac7db95886.png)
