### PR TITLE
chore: Bump libthermite version to 0.3.4

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1638,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "libthermite"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ada3d3086e6087c889d72e65450b93e42b069bdcf39377e9ba46db637a80b"
+checksum = "9ced5f2756672c1379a5ee41771af8e1ead525a9f6b1e2a2139105a6754f6bb5"
 dependencies = [
  "directories",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ steamlocate = "1.0.2"
 # Error messages
 anyhow = "1.0"
 # libthermite for Northstar/mod install handling
-libthermite = "0.3.3"
+libthermite = "0.3.4"
 # zip stuff
 zip = "0.6.2"
 # powershell interaction


### PR DESCRIPTION
Worked fine on my end. Resolves panic when trying to install `cat_or_not-mp_mirror_city-0.1.0` by throwing a catch-able error instead.