### PR TITLE
feat: Return Thunderstore mod string of installed mods.

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ pub struct GameInstall {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct NorthstarMod {
     pub name: String,
+    pub thunderstore_mod_string: Option<String>,
     pub enabled: bool,
 }
 

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -114,7 +114,7 @@ fn parse_installed_mods(game_install: GameInstall) -> Result<Vec<(String, Option
         let thunderstore_mod_string =
             match parse_mod_json_for_thunderstore_mod_string(mod_json_path.clone()) {
                 Ok(thunderstore_mod_string) => Some(thunderstore_mod_string),
-                Err(err) => None,
+                Err(_err) => None,
             };
 
         mods.push((mod_name, thunderstore_mod_string));

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -123,6 +123,7 @@ pub fn get_installed_mods_and_properties(
         };
         let current_mod: NorthstarMod = NorthstarMod {
             name: name,
+            thunderstore_mod_string: None,
             enabled: current_mod_enabled,
         };
         installed_mods.push(current_mod);

--- a/src-tauri/src/mod_management/mod.rs
+++ b/src-tauri/src/mod_management/mod.rs
@@ -56,7 +56,7 @@ fn parse_mod_json_for_mod_name(mod_json_path: String) -> Result<String, anyhow::
 }
 
 /// Parse `mods` folder for installed mods.
-fn get_installed_mods(game_install: GameInstall) -> Result<Vec<String>, String> {
+fn parse_installed_mods(game_install: GameInstall) -> Result<Vec<String>, String> {
     let ns_mods_folder = format!("{}/R2Northstar/mods/", game_install.game_path);
 
     let paths = std::fs::read_dir(ns_mods_folder).unwrap();
@@ -104,7 +104,7 @@ pub fn get_installed_mods_and_properties(
     game_install: GameInstall,
 ) -> Result<Vec<NorthstarMod>, String> {
     // Get actually installed mods
-    let found_installed_mods = get_installed_mods(game_install.clone())?;
+    let found_installed_mods = parse_installed_mods(game_install.clone())?;
 
     // Get enabled mods as JSON
     let enabled_mods: serde_json::Value = match get_enabled_mods(game_install) {

--- a/src-vue/src/utils/NorthstarMod.d.ts
+++ b/src-vue/src/utils/NorthstarMod.d.ts
@@ -1,5 +1,6 @@
 // Matches Rust struct (in lib.rs).
 export interface NorthstarMod {
     name: String,
+    thunderstore_mod_string?: String,
     enabled: bool,
 }


### PR DESCRIPTION
This updates the returned NorthstarMod struct/object to also contain the related Thunderstore mod that a Northstar mod may belong to.

- [x] Update struct in backend
- [x] Parse Thunderstore mod string and add it to respective mod struct
- [x] Update interface in frontend