### PR TITLE
feat: Allow custom TF|2 paths for debug builds

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -107,6 +107,24 @@ pub fn find_game_install_location() -> Result<GameInstall, String> {
         }
     };
 
+    // Other custom locations (for dev)
+    #[cfg(debug_assertions)]
+    {
+        let locations = [
+            "/your/path/here", // Replace this path with one pointing to a TF|2 install or add more below
+        ];
+        // Check if valid folder and valid Titanfall2 install path
+        for location in locations {
+            if std::path::Path::new(location).exists() && check_is_valid_game_path(location).is_ok() {
+                let game_install = GameInstall {
+                    game_path: location.to_string(),
+                    install_type: InstallType::UNKNOWN,
+                };
+                return Ok(game_install);
+            }
+        }
+    }
+
     Err("Could not auto-detect game install location! Please enter it manually.".to_string())
 }
 


### PR DESCRIPTION
The point behind this is to allow for custom paths for dev builds that can be hardcoded to allow pointing to some (fake) Titanfall2 install. That way when working on a machine with no proper Titanfall2 install or one where it's not being auto-detected, the path can be temporarily hardcoded by the developer to avoid having to select it on each recompile of the backend.

Obviously the added custom path should not be pushed and if pushed accidentally, rejected by PR reviewers.

[`#[cfg(debug_assertions)]`](https://github.com/GeckoEidechse/FlightCore/pull/57/commits/a8d72ef586f65db9073454a7db9287c2de0aca4f#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR111) ensures that the check is only performed in debug builds.