### PR TITLE
fix: Catch error for missing handle

### DIFF
--- a/src-vue/src/plugins/store.ts
+++ b/src-vue/src/plugins/store.ts
@@ -97,7 +97,12 @@ export const store = createStore<FlightCoreStore>({
                         type: 'success',
                         position: 'bottom-right'
                     });
-                    notification_handle.close();
+                    try {
+                        notification_handle.close();
+                    }
+                    catch {
+                        console.warn("Nothing to close");
+                    }
                     state.install_type = InstallType.UNKNOWN;
 
                     // Check for Northstar install


### PR DESCRIPTION
Setting install path manually when one exists already will error out on trying to delete the non-existing "no install found" notification using its non-existing handle.