### PR TITLE
edit: remove text about Viper showing stack trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The 3 main GUI tools for handling such tasks with Norhtstar are
 while they get most of the work done, each of them has their own problem.
 
 - **r2modman** has not too great UX and given that it also has to support other games there's not a(n easy) way to quickly add new features specific to Northstar
-- **Viper** probably has the best UX but is missing features such as Origin process runtime detection (to avoid LSX errors) and lacks the ability to install Northstar from Thunderstore. Further there are still cases where JavaScript errors are not handled properly simply showing the stack trace and confusing users.
+- **Viper** probably has the best UX but is missing features such as Origin process runtime detection (to avoid LSX errors) and lacks the ability to install Northstar from Thunderstore.
 - **VTOL** has recently undergone a rewrite that removes a lot of older issues (such as requiring to be run as admin), however it is Windows exclusive and requires installing an additional library not shipped directly with the application, confusing some users. It also has a lot of edge case handling that while giving a smoother user experience blows up code base complexity.
 
 With that said, FlightCore is not written from scratch. For handling Northstar specific logic, functions are re-used from the CLI-only Northstar installer called [papa](https://github.com/AnActualEmerald/papa) by making use of the underlying library [libthermite](https://crates.io/crates/libthermite).


### PR DESCRIPTION
With Viper 1.6.3, stack traces are not shown by default, instead a simple "Unknown Error!" toast is shown, where a user can choose to click it, to then see the stack.

Whether the text should be completely removed or not, is of course, not up to me, I just thought it would be an idea to at the very least, rephrase it, now that stack traces aren't shown by default.